### PR TITLE
Fix ``mypy`` Errors

### DIFF
--- a/src/arduino_cli_cmake_wrapper/cli.py
+++ b/src/arduino_cli_cmake_wrapper/cli.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import List
+from typing import Optional
 
 from .parse import parse_compilation_commands
 from .parse import parse_linker_commands
@@ -23,7 +24,7 @@ This tool will run a test compilation
 """
 
 
-def parse_arguments(arguments: List[str]) -> argparse.Namespace:
+def parse_arguments(arguments: Optional[List[str]]) -> argparse.Namespace:
     """Parse input arguments to influence the execution.
 
     The script needs to know where to copy the core library into the

--- a/src/arduino_cli_cmake_wrapper/cli.py
+++ b/src/arduino_cli_cmake_wrapper/cli.py
@@ -56,13 +56,13 @@ def parse_arguments(arguments: Optional[List[str]]) -> argparse.Namespace:
     return parser.parse_args(arguments)
 
 
-def main(arguments: List[str] = None):
+def main(cli_args_list: Optional[List[str]] = None):
     """Perform entrypoint functions."""
-    arguments = parse_arguments(arguments)
+    arguments = parse_arguments(cli_args_list)
 
-    with tempfile.TemporaryDirectory() as directory:
+    with tempfile.TemporaryDirectory() as directory_str:
         try:
-            directory = Path(directory)
+            directory = Path(directory_str)
             mappings = make_sketch(directory)
             compile_output = compile_sketch(arguments.board, directory)
 

--- a/src/arduino_cli_cmake_wrapper/parse.py
+++ b/src/arduino_cli_cmake_wrapper/parse.py
@@ -3,10 +3,13 @@ import shlex
 from pathlib import Path
 from typing import Dict
 from typing import List
+from typing import Optional
 
 
 def lines_between(
-    output_lines: List[str], start_phrase: str, end_phrase: str = None
+    output_lines: List[str],
+    start_phrase: str,
+    end_phrase: Optional[str] = None,
 ) -> List[str]:
     """Subset the supplied lines into those between start_phrase and end_phrase.
 


### PR DESCRIPTION
## 🛰️ Overview

Fix ``mypy`` typing errors in the codebase.  There are no functional adjustments being made to the code.

## ✨ Change Description/Rationale

- 🚨 Fix ``no_implicit_optional`` type hinting error

PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its
default to ``no_implicit_optional=True``

The tool https://github.com/hauntsaninja/no_implicit_optional was used
to automatically upgrade the codebase.

- 🚨 Fix incompatible types assignment in ``main`` function signature

The following error in ``mypy`` is a result of re-assigning
``arguments``:

error: Incompatible types in assignment (expression has type
"Namespace", variable has type "Optional[List[str]]")  [assignment]

The solution is to avoid the use of the pattern that ``argparse``
suggests, because it causes type shadowing that is hard for humans and
hard for ``mypy`` to read.  The following resource does a good job
explaining the problem and solution:

https://adamj.eu/tech/2021/05/23/python-type-hints-mypy-doesnt-allow-variables-to-change-type/

## 🧪 Test Coverage

There are no changes relevant to this section.

## 🚨 Quality Deviations

Test do not pass, but that will be handled in a different PR.

## 👀 Reviewer Checklist

- [x] Run ``tox -e mypy`` to see that the code is now type-hinted correctly.

## ✅ PR Checklist

- [x] Remove or update the PR template boilerplate text
- [x] Reviewers Requested
- [x] Labels added
- [x] Projects associated
- [x] Milestone assigned
- [x] All docstrings are formatted as google docstrings with filled out types and explanations; Any code that was edited and contains a prose description of the functional execution, and preferably a ``doctest`` compatible example
- [x] Docstring examples are all ``doctest`` compliant
- [x] Any file or folder names are manipulated via ``pathlib.Path``
- [x] Non-public imports and API elements are prefixed with a single underscore or the package ``__all__`` variable is set
- [x] All ``noqa`` statements for skipping lint rules are justified
- [x] Commits mention issue and/or PR numbers at the bottom of the message with the [Username/Repository#](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) format
- [x] Relevant issues are linked into the PR (issues mentioned in overview should link for you)
- [x] TODOs are completed
- [x] Reviewer checklist is updated

## 🚀 TODOs

- [x] None

## 📌 Future Work

- Tests do not pass and will be addressed in a future PR.
