### PR TITLE
🔧 Update ``flake8`` target repository in ``pre-commit`` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
## 🛰️ Overview

This fixes the ``lint`` target in the github actions by updating the link in the ``pre-commit`` configuration.

## ✨ Change Description/Rationale

- 🔧 Update ``flake8`` target repository in ``pre-commit`` configuration

## 🧪 Test Coverage

No code adjusted in this PR.

## ✅ PR Checklist

(These are not all checked by the submitter, only check the items that are _actually_ complete)

- [x] Remove or update the PR template boilerplate text
- [x] Milestone assigned
